### PR TITLE
Add time/progress slider

### DIFF
--- a/PluginUI.cs
+++ b/PluginUI.cs
@@ -38,6 +38,17 @@ public static unsafe class PluginUI
         return (uint)(unit->RootNode->Width * unit->RootNode->ScaleX);
     }
 
+    private static unsafe float GetGameUIScale()
+    {
+        RaptureAtkUnitManager* manager = AtkStage.GetSingleton()->RaptureAtkUnitManager;
+        if (manager == null) return 1.0f;
+
+        AtkUnitBase* unit = manager->GetAddonByName("ContentsReplayPlayer");
+        if (unit == null) return 1.0f;
+
+        return unit->GetGlobalUIScale();
+    }
+
     public static void Draw()
     {
         DrawExpandedDutyRecorderMenu();
@@ -170,7 +181,7 @@ public static unsafe class PluginUI
         if (addon == null) return;
 
         ImGuiHelpers.ForceNextWindowMainViewport();
-        ImGui.SetNextWindowPos(new(addon->X, addon->Y), ImGuiCond.Always, Vector2.UnitY);
+        ImGui.SetNextWindowPos(new(addon->X + (8 * GetGameUIScale()), addon->Y), ImGuiCond.Always, Vector2.UnitY);
         ImGui.Begin("Expanded Playback", ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoSavedSettings);
 
         if (showSettings && !Game.IsLoadingChapter)

--- a/PluginUI.cs
+++ b/PluginUI.cs
@@ -280,10 +280,11 @@ public static unsafe class PluginUI
         if (ImGui.IsItemHovered()) {
             var mouse_pos = ImGui.GetMousePos().X;
             var slider_pos = ImGui.GetItemRectMin().X;
-            var preview_ms = (mouse_pos - slider_pos) / slider_width * (seek_max / 1000.0f);
-            if (preview_ms >= 0.0f && preview_ms <= (seek_max / 1000.0f))
+            var completion = (mouse_pos - slider_pos) / slider_width;
+            if (completion >= 0.0f && completion <= 1.0f)
             {
-                var preview_time = preview_ms + start_ms;
+                var preview_ms = completion * (seek_max / 1000.0f);
+                var preview_time = preview_ms + seek_min;
                 var preview_hours = MathF.Floor(preview_time / 3600.0f).ToString().PadLeft(2, '0');
                 var preview_minutes = MathF.Floor((preview_time % 3600.0f) / 60.0f).ToString().PadLeft(2, '0');
                 var preview_seconds = MathF.Truncate(preview_time % 60.0f).ToString().PadLeft(2, '0');

--- a/PluginUI.cs
+++ b/PluginUI.cs
@@ -262,12 +262,12 @@ public static unsafe class PluginUI
         var slider_width = GetUIWidth() - (2 * ImGui.CalcTextSize("Speed").X);
         ImGui.SetNextItemWidth(slider_width);
         var start_ms = (float)Game.ffxivReplay->startingMS / 1000.0f;
+        var end_ms = (float)Game.ffxivReplay->replayHeader.ms / 1000.0f;
         var seek_min = Game.ffxivReplay->seek - start_ms;
-        var seek_max = Game.ffxivReplay->replayHeader.ms;
         var hours = MathF.Floor(seek_min / 3600.0f).ToString().PadLeft(2, '0');
         var minutes = MathF.Floor((seek_min % 3600.0f) / 60.0f).ToString().PadLeft(2, '0');
         var seconds = MathF.Truncate(seek_min % 60.0f).ToString().PadLeft(2, '0');
-        if (ImGui.SliderFloat("Time", ref seek_min, 0.0f, (float)seek_max / 1000.0f, $"{hours}:{minutes}:{seconds}", ImGuiSliderFlags.NoInput)) {
+        if (ImGui.SliderFloat("Time", ref seek_min, 0.0f, end_ms, $"{hours}:{minutes}:{seconds}", ImGuiSliderFlags.NoInput)) {
             var time = seek_min + start_ms;
             var time_ms = (uint)(time * 1000.0f);
             var seg = Game.FindNextDataSegment(time_ms, out var offset);
@@ -283,13 +283,13 @@ public static unsafe class PluginUI
             var completion = (mouse_pos - slider_pos) / slider_width;
             if (completion >= 0.0f && completion <= 1.0f)
             {
-                var preview_ms = completion * (seek_max / 1000.0f);
-                var preview_time = preview_ms + seek_min;
+                var preview_time = (completion * end_ms);
                 var preview_hours = MathF.Floor(preview_time / 3600.0f).ToString().PadLeft(2, '0');
                 var preview_minutes = MathF.Floor((preview_time % 3600.0f) / 60.0f).ToString().PadLeft(2, '0');
                 var preview_seconds = MathF.Truncate(preview_time % 60.0f).ToString().PadLeft(2, '0');
                 ImGui.BeginTooltip();
                 ImGui.Text($"{preview_hours}:{preview_minutes}:{preview_seconds}");
+                ImGui.Text(completion.ToString());
                 ImGui.EndTooltip();
             }
         }


### PR DESCRIPTION
Was using this with my FC to analyze some mechanics from some of our runs, and we found it pretty weird that the vanilla UI didn't let you manually seek the replay. I added this to the plugin. You can seek both forwards and backwards. This isn't perfect, it's just a quick implementation. I noticed that it will sometimes spam the "Duty Complete" or started message. Additionally, the interpolation that the game applies to the game objects is really ugly here.