### PR TITLE
Display the replays in a sortable table instead of a list

### DIFF
--- a/Game.cs
+++ b/Game.cs
@@ -13,6 +13,7 @@ using Dalamud.Utility.Signatures;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using ImGuiNET;
 
 namespace ARealmRecorded;
 
@@ -571,6 +572,32 @@ public unsafe class Game
         }
 
         return replayList;
+    }
+
+    public static void SortReplayList(ImGuiTableSortSpecsPtr sortspecs)
+    {
+        if (sortspecs.Specs.ColumnIndex == 0) // sort by date
+        {
+            if (sortspecs.Specs.SortDirection == ImGuiSortDirection.Ascending)
+            {
+                replayList = ReplayList.OrderByDescending(t => t.Item2.IsPlayable).ThenBy(t => t.Item1.CreationTime).ToList();
+            }
+            else
+            {
+                replayList = Game.ReplayList.OrderByDescending(t => t.Item2.IsPlayable).ThenByDescending(t => t.Item1.CreationTime).ToList();
+            }
+        }
+        else // sort by name
+        {
+            if (sortspecs.Specs.SortDirection == ImGuiSortDirection.Ascending)
+            {
+                replayList = Game.ReplayList.OrderByDescending(t => t.Item2.IsPlayable).ThenBy(t => t.Item1.Name).ToList();
+            }
+            else
+            {
+                replayList = Game.ReplayList.OrderByDescending(t => t.Item2.IsPlayable).ThenByDescending(t => t.Item1.Name).ToList();
+            }
+        }
     }
 
     public static void RenameRecording(FileInfo file, string name)

--- a/Game.cs
+++ b/Game.cs
@@ -592,7 +592,7 @@ public unsafe class Game
             var fileName = GetReplaySlotName(currentRecordingSlot);
             var (file, _) = GetReplayList().First(t => t.Item1.Name == fileName);
 
-            var name = $"{bannedFolderCharacters.Replace(ffxivReplay->contentTitle.ToString(), string.Empty)} {DateTime.Now:yyyy.MM.dd HH.mm.ss}";
+            var name = $"{bannedFolderCharacters.Replace(ffxivReplay->contentTitle.ToString(), string.Empty)}@{DateTime.Now:yyyy.MM.dd HH.mm.ss}";
             file.MoveTo(Path.Combine(autoRenamedFolder, $"{name}.dat"));
 
             var renamedFiles = new DirectoryInfo(autoRenamedFolder).GetFiles().Where(f => f.Extension == ".dat").ToList();

--- a/Game.cs
+++ b/Game.cs
@@ -561,7 +561,7 @@ public unsafe class Game
                     let header = ReadReplayHeader(file.FullName)
                     where header is { IsValid: true }
                     select (file, header.Value)
-                ).OrderByDescending(t => t.Value.IsPlayable).ThenBy(t => t.file.Name).ToList();
+                ).OrderByDescending(t => t.Value.IsPlayable).ThenByDescending(t => t.file.CreationTime).ToList();
 
             replayList = list;
         }

--- a/PluginUI.cs
+++ b/PluginUI.cs
@@ -73,7 +73,7 @@ public static unsafe class PluginUI
         var addonH = (addon->RootNode->GetHeight() - 11) * addon->Scale;
         ImGuiHelpers.ForceNextWindowMainViewport();
         ImGui.SetNextWindowPos(new(addon->X + addonW, addon->Y));
-        ImGui.SetNextWindowSize(new Vector2(400 * ImGuiHelpers.GlobalScale, addonH));
+        ImGui.SetNextWindowSize(new Vector2(500 * ImGuiHelpers.GlobalScale, addonH));
         ImGui.Begin("Expanded Duty Recorder", ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoSavedSettings);
 
         ImGui.PushFont(UiBuilder.IconFont);

--- a/PluginUI.cs
+++ b/PluginUI.cs
@@ -120,7 +120,7 @@ public static unsafe class PluginUI
 
                 ImGui.TableNextRow();
                 ImGui.TableNextColumn();
-                ImGui.Text(creationTime.ToString("yyyy.MM.dd HH.mm.ss"));
+                ImGui.Text(creationTime.ToString("yyyy.MM.dd HH:mm:ss"));
                 ImGui.TableNextColumn();
 
                 if (editingRecording != i)

--- a/PluginUI.cs
+++ b/PluginUI.cs
@@ -108,7 +108,7 @@ public static unsafe class PluginUI
                 if (!isPlayable)
                     ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetColorU32(ImGuiCol.TextDisabled));
 
-                if (ImGui.Selectable(file.Directory?.Name == "autorenamed" ? $"◯ {name}" : name, path == Game.lastSelectedReplay && *(byte*)(agent + 0x2C) == 100))
+                if (ImGui.Selectable(file.Directory?.Name == "autorenamed" ? $"{file.CreationTime:yyyy.MM.dd HH.mm.ss} | {name.Substring(0,name.IndexOf('@'))}" : name, path == Game.lastSelectedReplay && *(byte*)(agent + 0x2C) == 100))
                     Game.SetDutyRecorderMenuSelection(agent, path, header);
 
                 if (!isPlayable)

--- a/PluginUI.cs
+++ b/PluginUI.cs
@@ -99,6 +99,14 @@ public static unsafe class PluginUI
         {
             ImGui.TableSetupColumn("Date", ImGuiTableColumnFlags.DefaultSort);
             ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch);
+            ImGui.TableHeadersRow();
+
+            if (ImGui.TableGetSortSpecs().SpecsDirty)
+            {
+                var sortspecs = ImGui.TableGetSortSpecs();
+                Game.SortReplayList(sortspecs);
+                sortspecs.SpecsDirty = false;
+            }
 
             for (int i = 0; i < Game.ReplayList.Count; i++)
             {


### PR DESCRIPTION
pretty much what it says on the box. Additionally, replays get sorted by date by default, instead of by name.

the only downside is that the autorename now works differently, (somewhat) breaking backwards compatability.

known issues:
- when renaming a replay, the InputText doesnt fill the full width of the column it is in, making renaming replays kinda awkward. unsure how to fix it, exactly, since i havent used imgui before.
- the selected sorting doesnt persist between reloads of the plugin.

edit: figured i should probably add a short demo video

https://user-images.githubusercontent.com/11347524/230766280-0d43bc16-87a8-4968-a71f-667a7e6adcdc.mp4 