### PR TITLE
Fixed window offset in multi-monitor

### DIFF
--- a/PlaybackControlsUI.cs
+++ b/PlaybackControlsUI.cs
@@ -77,7 +77,7 @@ public static unsafe class PlaybackControlsUI
         var addonW = addon->RootNode->GetWidth() * addon->Scale;
         var addonPadding = addon->Scale * 8;
         ImGuiHelpers.ForceNextWindowMainViewport();
-        ImGui.SetNextWindowPos(new(addon->X + addonPadding, addon->Y + addonPadding), ImGuiCond.Always, Vector2.UnitY);
+        ImGui.SetNextWindowPos(new Vector2(addon->X + addonPadding, addon->Y + addonPadding) + ImGuiHelpers.MainViewport.Pos, ImGuiCond.Always, Vector2.UnitY);
         ImGui.SetNextWindowSize(new Vector2(addonW - addonPadding * 2, 0));
         ImGui.Begin("Expanded Playback", ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoSavedSettings);
 

--- a/ReplayListUI.cs
+++ b/ReplayListUI.cs
@@ -46,7 +46,7 @@ public static unsafe class ReplayListUI
             var addonW = addon->RootNode->GetWidth() * addon->Scale;
             var addonH = (addon->RootNode->GetHeight() - 11) * addon->Scale;
             ImGuiHelpers.ForceNextWindowMainViewport();
-            ImGui.SetNextWindowPos(new(addon->X + addonW, addon->Y));
+            ImGui.SetNextWindowPos(new Vector2(addon->X + addonW, addon->Y) + ImGuiHelpers.MainViewport.Pos);
             ImGui.SetNextWindowSize(new Vector2(500 * ImGuiHelpers.GlobalScale, addonH));
             ImGui.Begin("##ExpandedContentsReplaySetting", ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoSavedSettings);
         }


### PR DESCRIPTION
Fixed a problem where the UI was drawn based on the upper left corner of the monitor when Dalamud's `Enable multi-monitor windows` option was enabled.