### PR TITLE
Fix crashes on long replays

### DIFF
--- a/Game.cs
+++ b/Game.cs
@@ -205,17 +205,24 @@ public static unsafe class Game
     private static nint FormatAddonTextTimestampDetour(nint raptureTextModule, uint addonSheetRow, int a3, uint hours, uint minutes, uint seconds, uint a7)
     {
         var ret = FormatAddonTextTimestampHook.Original(raptureTextModule, addonSheetRow, a3, hours, minutes, seconds, a7);
-        if (addonSheetRow != 3079 || !DalamudApi.PluginInterface.UiBuilder.ShouldModifyUi) return ret;
-
-        // In this context, a3 is the chapter index + 1, while a7 determines the chapter type name
-        var currentChapterMS = Common.ContentsReplayModule->chapters[a3 - 1]->ms;
-        var nextChapterMS = Common.ContentsReplayModule->chapters[a3]->ms;
-        if (nextChapterMS < currentChapterMS)
-            nextChapterMS = Common.ContentsReplayModule->replayHeader.totalMS;
-
-        var timespan = new TimeSpan(0, 0, 0, 0, (int)(nextChapterMS - currentChapterMS));
-        (ret + ret.ReadCString().Length).WriteCString($" ({(int)timespan.TotalMinutes:D2}:{timespan.Seconds:D2})");
-
+        try
+        {
+            if(addonSheetRow != 3079 || !DalamudApi.PluginInterface.UiBuilder.ShouldModifyUi) return ret;
+    
+            // In this context, a3 is the chapter index + 1, while a7 determines the chapter type name
+            var currentChapterMS = Common.ContentsReplayModule->chapters[a3 - 1]->ms;
+            if(a3 >= 64) return ret;
+            var nextChapterMS = Common.ContentsReplayModule->chapters[a3]->ms;
+            if(nextChapterMS < currentChapterMS)
+                nextChapterMS = Common.ContentsReplayModule->replayHeader.totalMS;
+    
+            var timespan = new TimeSpan(0, 0, 0, 0, (int)(nextChapterMS - currentChapterMS));
+            (ret + ret.ReadCString().Length).WriteCString($" ({(int)timespan.TotalMinutes:D2}:{timespan.Seconds:D2})");
+        }
+        catch(Exception e)
+        {
+            DalamudApi.LogError(e.ToString());
+        }
         return ret;
     }
 


### PR DESCRIPTION
Since there can only be 64 segments, when text is formatted for 64th, next one will be null and it will cause an exception