### PR TITLE
Add NTFS compression and option to not hide during cutscenes

### DIFF
--- a/ARealmRecorded.csproj
+++ b/ARealmRecorded.csproj
@@ -5,5 +5,11 @@
         <Nullable>disable</Nullable>
         <AppendPlatformToOutputPath>false</AppendPlatformToOutputPath>
     </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="TerraFX.Interop.Windows">
+            <HintPath>$(DalamudLibPath)TerraFX.Interop.Windows.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+    </ItemGroup>
 
 </Project>

--- a/ARealmRecorded.json
+++ b/ARealmRecorded.json
@@ -12,6 +12,5 @@
     "utility"
   ],
   "InternalName": "ARealmRecorded",
-  "AssemblyVersion": "9.9.9.9",
-  "DalamudApiLevel": 15
+  "AssemblyVersion": "9.9.9.9"
 }

--- a/ARealmRecorded.json
+++ b/ARealmRecorded.json
@@ -12,5 +12,6 @@
     "utility"
   ],
   "InternalName": "ARealmRecorded",
-  "AssemblyVersion": "9.9.9.9"
+  "AssemblyVersion": "9.9.9.9",
+  "DalamudApiLevel": 15
 }

--- a/Configuration.cs
+++ b/Configuration.cs
@@ -16,4 +16,6 @@ public class Configuration : PluginConfiguration, IPluginConfiguration
     public float MaxSeekDelta = 100;
     public float CustomSpeedPreset = 30;
     public bool EnableWaymarks = true;
+    public bool HideDuringCutscenes = true;
+    public bool UseNTFSCompression = false;
 }

--- a/Game.cs
+++ b/Game.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.Config;
 using Dalamud.Hooking;
+using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using Hypostasis.Game.Structures;
@@ -351,7 +352,13 @@ public static unsafe class Game
             var (file, replay) = GetReplayList().Where(t => t.Item1.Name.StartsWith("FFXIV_")).MaxBy(t => t.Item1.LastWriteTime);
 
             var name = $"{bannedFileCharacters.Replace(Common.ContentsReplayModule->contentTitle.ToString(), string.Empty)} {DateTime.Now:yyyy.MM.dd HH.mm.ss}";
-            file.MoveTo(Path.Combine(autoRenamedFolder, $"{name}.dat"));
+            var destination = Path.Combine(autoRenamedFolder, $"{name}.dat");
+            file.MoveTo(destination);
+            if(ARealmRecorded.Config.UseNTFSCompression && Dalamud.Utility.Util.GetHostPlatform() == OSPlatform.Windows && Utility.IsOnCompressibleNtfsDrive(destination))
+            {
+                Utility.RequestFileCompression(destination);
+                DalamudApi.LogDebug($"Requested compression of {destination}");
+            }
 
             var renamedFiles = new DirectoryInfo(autoRenamedFolder).GetFiles().Where(f => f.Extension == ".dat").ToList();
             while (renamedFiles.Count > ARealmRecorded.Config.MaxAutoRenamedReplays)

--- a/PlaybackControlsUI.cs
+++ b/PlaybackControlsUI.cs
@@ -39,7 +39,7 @@ public static unsafe class PlaybackControlsUI
             return;
         }
 
-        if (DalamudApi.GameGui.GetAddonByName("TalkSubtitle") != nint.Zero) return; // Hide during cutscenes
+        if (ARealmRecorded.Config.HideDuringCutscenes && DalamudApi.GameGui.GetAddonByName("TalkSubtitle") != nint.Zero) return; // Hide during cutscenes
 
         if (Common.ContentsReplayModule->seek != lastSeek || Common.ContentsReplayModule->IsPaused)
         {

--- a/ReplayListUI.cs
+++ b/ReplayListUI.cs
@@ -361,6 +361,11 @@ public static unsafe class ReplayListUI
         save |= ImGui.InputInt("Max Deleted Replays", ref ARealmRecorded.Config.MaxDeletedReplays);
         ImGuiEx.SetItemTooltip("Max number of replays to keep in the deleted folder.");
 
+        save |= ImGui.Checkbox("Hide Control During Cutscenes", ref ARealmRecorded.Config.HideDuringCutscenes);
+
+        save |= ImGui.Checkbox("Compress Replays (Windows only, NTFS drives only)", ref ARealmRecorded.Config.UseNTFSCompression);
+        ImGuiEx.SetItemTooltip("Replays will be compressed to approximately 1/3th of original size using built-in NTFS compression. Replays will load slightly slower with this option enabled (there will be no effect on recording on playback though). ");
+
         if (save)
             ARealmRecorded.Config.Save();
 

--- a/Utility.cs
+++ b/Utility.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using TerraFX.Interop.Windows;
+
+namespace ARealmRecorded;
+
+public static class Utility
+{
+    public static unsafe void RequestFileCompression(string filePath)
+    {
+        try
+        {
+            using var handle = File.OpenHandle(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete, FileOptions.None);
+            var format = TerraFX.Interop.Windows.Windows.COMPRESSION_FORMAT_DEFAULT;
+            TerraFX.Interop.Windows.Windows.DeviceIoControl((HANDLE)handle.DangerousGetHandle(), FSCTL.FSCTL_SET_COMPRESSION, &format, sizeof(ushort), null, 0, null, null);
+        }
+        catch(Exception ex)
+        {
+            DalamudApi.LogError(ex.ToString());
+        }
+    }
+
+    public static unsafe bool IsOnCompressibleNtfsDrive(string filePath)
+    {
+        char* volumeNameBuffer = null;
+        char* fsNameBuffer = null;
+        try
+        {
+            var fullPath = Path.GetFullPath(filePath);
+            var root = Path.GetPathRoot(fullPath);
+
+            if(string.IsNullOrEmpty(root))
+            {
+                return false;
+            }
+
+            var bufferSize = 32768u;
+            volumeNameBuffer = (char*)NativeMemory.AllocZeroed(bufferSize);
+            fsNameBuffer = (char*)NativeMemory.AllocZeroed(bufferSize);
+
+            uint serialNumber;
+            uint maxComponentLength;
+            uint flags;
+
+            fixed(char* rootPtr = root)
+            {
+                var result = TerraFX.Interop.Windows.Windows.GetVolumeInformationW(rootPtr, volumeNameBuffer, bufferSize, &serialNumber, &maxComponentLength, &flags, fsNameBuffer, bufferSize);
+
+                if(result == TerraFX.Interop.Windows.Windows.FALSE)
+                {
+                    return false;
+                }
+            }
+
+            var fsName = new string(fsNameBuffer);
+
+            var isNtfs = fsName.Equals("NTFS", StringComparison.OrdinalIgnoreCase);
+            var supportsComp = (flags & FILE.FILE_FILE_COMPRESSION) != 0;
+
+            return isNtfs && supportsComp;
+        }
+        catch(Exception ex)
+        {
+            DalamudApi.LogError(ex.ToString());
+            return false;
+        }
+        finally
+        {
+            if(volumeNameBuffer != null)
+            {
+                NativeMemory.Free(volumeNameBuffer);
+            }
+
+            if(fsNameBuffer != null)
+            {
+                NativeMemory.Free(fsNameBuffer);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Replays can get rather big, NTFS compression will help to save space. And also made UI hiding during cutscene toggleable